### PR TITLE
Attempt to fix button styling issues for iOS Safari

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -157,6 +157,8 @@ header > nav[is="responsive-site-navigation-element"] {
     /* Modified styles for the custom element (if it is succesfully loaded/progressively-enhanced) */
     &[data-defined="true"] {
         container-type: inline-size;
+        display: flex;
+        justify-content: end;
 
         > [is="dialog-modal-element"] {
             height: 100%;
@@ -281,4 +283,9 @@ header > nav[is="responsive-site-navigation-element"] {
             }
         }
     }
+}
+
+button {
+    background-color: #efefef;
+    color: var(--color);
 }


### PR DESCRIPTION
1. Attempt to "Site Navigation Menu" ("Menu") control alignment (it wasn't positioned correctly on iOS Safari).
2. Override the user agent stylesheet defaults for `background-color` and `color` for `<button>` elements (the text color in iOS Safari was looking [potentially] too low contrast relative to its background color)